### PR TITLE
Fix filename typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Fill in the CTFd URL, API key, output directory, and CTF name in script.
 
 #### Run The Downloader
 
-    python downloader.py
+    python download.py


### PR DESCRIPTION
Changed incorrect filename "downloader.py" to the actual filename "download.py" in README.md