### PR TITLE
Update download.py

### DIFF
--- a/download.py
+++ b/download.py
@@ -92,19 +92,19 @@ def main(argv):
             with open(os.path.join(challDir, "README.md"), "w") as chall_readme:
                 logging.info("Creating challenge readme: %s" % Y["name"])
                 chall_readme.write("# %s\n\n" % Y["name"])
-                chall_readme.write("## Description\n\n%s\n\n" % Y["description"])
+                chall_readme.write("## Description\n\n%s\n\n" % Y.get("description", "N\A"))
 
                 files_header = False
 
                 # Find links in description
-                links = re.findall(r'(https?://[^\s]+)', Y["description"])
+                links = re.findall(r'(https?://[^\s]+)', Y.get("description", "N\A"))
 
                 if len(links) > 0:
                     for link in links:
                         desc_links.append((Y["name"], link))
 
                 # Find MD images in description
-                md_links = re.findall(r'!\[(.*)\]\(([^\s]+)\)', Y["description"])
+                md_links = re.findall(r'!\[(.*)\]\(([^\s]+)\)', Y.get("description", "N\A"))
 
                 if len(md_links) > 0:
                     for link_desc, link in md_links:


### PR DESCRIPTION
For the USCG openctf, there were some old challenges that were causing issues. I didn't look too closely but it seems the API was returning a json object without a "description" key sometimes, which caused the script to have a KeyError. This patch uses .get(blah, "N/A"), so that they key is created with the value "N/A" if the description key isn't sent.