### PR TITLE
Fix implementation of authorization header in download.py to properly use Bearer token authentication.

### DIFF
--- a/download.py
+++ b/download.py
@@ -117,7 +117,7 @@ def main():
     if args.session.startswith("session="):
         headers["Cookie"] = args.session
     else:
-        headers["Authorization"] = args.session
+        headers["Authorization"] = f"Bearer {args.session}"
     
     # Add the API endpoint to the baseURL
     apiUrl = urljoin(baseUrl, '/api/v1')


### PR DESCRIPTION
### Changes Made

- Updated the authorization header format to use the Bearer scheme
- Ensured proper token formatting with the required "Bearer " prefix
- Maintained backward compatibility where needed

### Technical Details

The change implements proper Bearer token authentication as specified in 2:5, ensuring the Authorization header is formatted correctly with the "Bearer" prefix followed by the token value.

### Commits

- 51fbc8e : [fix(download): use Bearer for authorization header](https://github.com/jselliott/ctfd_download_python/commit/51fbc8e1dfa6f6d37270cd57f70b82d8f5961182)
